### PR TITLE
fix: forward Reply-To addresses to zeptomail API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodemailer-zeptomail-transport",
-  "version": "1.0.12",
+  "version": "1.0.14",
   "description": "Small transport plugin for Zeptomail API and Nodemailer v4+.",
   "author": "Abimbola Hassan <infitizon@gmail.com>",
   "license": "MIT",

--- a/src/models/Zeptomail.ts
+++ b/src/models/Zeptomail.ts
@@ -23,16 +23,7 @@ export namespace Zeptomail {
     }
     return {};
   };
-  // const appendReplyTo = (data: SendMailOptions): To[] => {
-  //   const accumulator: To[] = [];
-  //   if (data['replyTo']) return [];
-  //   const to = (data['replyTo'] as Address);
-  //   accumulator.push({
-  //     address: to.address,
-  //     name: to.name
-  //   });
-  //   return accumulator;
-  // };
+
   const appendAddresses = (data: SendMailOptions, type: To['type']): {email_address: To}[] => {
     const accumulator: {email_address: To}[] = [];
     if (!type || !data[type!]) return [];
@@ -45,6 +36,14 @@ export namespace Zeptomail {
       });
     });
     return accumulator;
+  };
+
+  /**
+   * like appendAddresses but doesn't nest the addresses with the email_address key
+   */
+  const appendReplyTo = (data: SendMailOptions): To[] => {
+    if (!data['replyTo']) return [];
+    return data['replyTo'] as Address[];
   };
 
   const appendAttachments = (data: SendMailOptions): Attachments[] => {
@@ -86,7 +85,7 @@ export namespace Zeptomail {
         to: appendAddresses(data, 'to'),
         cc: appendAddresses(data, 'cc'),
         bcc: appendAddresses(data, 'bcc'),
-        // reply_to: appendReplyTo(data),
+        reply_to: appendReplyTo(data),
         subject: data.subject,
         textbody: data.text,
         htmlbody: data.html,


### PR DESCRIPTION
This fix enables the `replyTo` field.

I have also updated the version number to 1.0.14 so you can release this without any further adjustments.